### PR TITLE
Changes for works with hyprland-v0.40 socketpath + fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 	if out != "" {
-		printOut(string(out))
+		printOut(out)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -10,7 +11,10 @@ import (
 
 func main() {
 	command, err := hyprwin.HandleCli()
-	if err != nil {
+	if errors.Is(err, hyprwin.ErrHelpRequested) {
+		fmt.Println(hyprwin.Usage)
+		os.Exit(0)
+	} else if err != nil {
 		printErr(err)
 		os.Exit(1)
 	}

--- a/pkg/hyprwin/cli.go
+++ b/pkg/hyprwin/cli.go
@@ -23,6 +23,13 @@ Directions:
     l,r,u,d         For left, right, up, down
     mon:<monitor>   Only for movefocus dispatcher`
 
+var (
+	ErrNotEnoughArgs       = errors.New("not enough arguments, expected 2")
+	ErrTooManyArgs         = errors.New("too many arguments, expected 2")
+	ErrIncorrectDispatcher = errors.New("incorrect dispatcher received")
+	ErrIncorrectDirection  = errors.New("incorrect direction received")
+)
+
 type (
 	dispatcher string
 	direction  string
@@ -84,26 +91,27 @@ func helpRequested(args []string) bool {
 
 func HandleCli() (cmd *command, err error) {
 	args := os.Args[1:]
-	if len(args) < 2 {
-		fmt.Print(Usage)
-		return nil, errors.New("not enough arguments")
-	}
 
 	if helpRequested(args) {
 		fmt.Println(Usage)
 		os.Exit(0)
 	}
 
+	if len(args) < 2 {
+		fmt.Print(Usage)
+		return nil, ErrNotEnoughArgs
+	}
+
 	if len(args) != 2 {
-		return nil, errors.New("incorrect number of arguments: expected 2")
+		return nil, ErrTooManyArgs
 	}
 
 	dp, dir := dispatcher(args[0]), direction(args[1])
 	if !dp.IsValid() {
-		return nil, errors.New("incorrect dispatcher received")
+		return nil, ErrIncorrectDispatcher
 	}
 	if !dir.IsValid(dp) {
-		return nil, errors.New("incorrect direction received")
+		return nil, ErrIncorrectDirection
 	}
 
 	return &command{dp, dir}, nil

--- a/pkg/hyprwin/cli.go
+++ b/pkg/hyprwin/cli.go
@@ -84,7 +84,7 @@ func helpRequested(args []string) bool {
 
 func HandleCli() (cmd *command, err error) {
 	args := os.Args[1:]
-	if len(args) == 0 {
+	if len(args) < 2 {
 		fmt.Print(Usage)
 		return nil, errors.New("not enough arguments")
 	}

--- a/pkg/hyprwin/cli.go
+++ b/pkg/hyprwin/cli.go
@@ -24,6 +24,7 @@ Directions:
     mon:<monitor>   Only for movefocus dispatcher`
 
 var (
+	ErrHelpRequested       = errors.New("help requested")
 	ErrNotEnoughArgs       = errors.New("not enough arguments, expected 2")
 	ErrTooManyArgs         = errors.New("too many arguments, expected 2")
 	ErrIncorrectDispatcher = errors.New("incorrect dispatcher received")
@@ -93,8 +94,7 @@ func HandleCli() (cmd *command, err error) {
 	args := os.Args[1:]
 
 	if helpRequested(args) {
-		fmt.Println(Usage)
-		os.Exit(0)
+		return nil, ErrHelpRequested
 	}
 
 	if len(args) < 2 {

--- a/pkg/hyprwin/cli.go
+++ b/pkg/hyprwin/cli.go
@@ -32,53 +32,53 @@ var (
 )
 
 type (
-	dispatcher string
-	direction  string
+	DispatcherCmd string
+	DirectionArg  string
 )
 
 var (
-	dispatchers = []dispatcher{
-		dispatcher("movefocus"),
-		dispatcher("movewindow"),
+	dispatchers = []DispatcherCmd{
+		DispatcherCmd("movefocus"),
+		DispatcherCmd("movewindow"),
 	}
-	directions = []direction{
-		direction("l"),
-		direction("r"),
-		direction("u"),
-		direction("d"),
+	directions = []DirectionArg{
+		DirectionArg("l"),
+		DirectionArg("r"),
+		DirectionArg("u"),
+		DirectionArg("d"),
 	}
 )
 
-func (dp dispatcher) Str() string {
+func (dp DispatcherCmd) Str() string {
 	return string(dp)
 }
 
-func (dp dispatcher) IsValid() bool {
+func (dp DispatcherCmd) IsValid() bool {
 	return slices.Contains(dispatchers, dp)
 }
 
-func (dir direction) Str() string {
+func (dir DirectionArg) Str() string {
 	return string(dir)
 }
 
-func (dir direction) ToMonitor() bool {
+func (dir DirectionArg) ToMonitor() bool {
 	return strings.HasPrefix(dir.Str(), "mon:")
 }
 
-func (dir direction) IsValid(dp dispatcher) bool {
+func (dir DirectionArg) IsValid(dp DispatcherCmd) bool {
 	isBaseDir := slices.Contains(directions, dir)
 	switch dp {
-	case dispatcher("movefocus"):
+	case DispatcherCmd("movefocus"):
 		return isBaseDir
-	case dispatcher("movewindow"):
+	case DispatcherCmd("movewindow"):
 		return isBaseDir || dir.ToMonitor()
 	}
 	return false
 }
 
-type command struct {
-	dispatcher dispatcher
-	direction  direction
+type CommandRequest struct {
+	dispatcher DispatcherCmd
+	direction  DirectionArg
 }
 
 func helpRequested(args []string) bool {
@@ -90,7 +90,7 @@ func helpRequested(args []string) bool {
 	return false
 }
 
-func HandleCli() (cmd *command, err error) {
+func HandleCli() (cmd *CommandRequest, err error) {
 	args := os.Args[1:]
 
 	if helpRequested(args) {
@@ -106,7 +106,7 @@ func HandleCli() (cmd *command, err error) {
 		return nil, ErrTooManyArgs
 	}
 
-	dp, dir := dispatcher(args[0]), direction(args[1])
+	dp, dir := DispatcherCmd(args[0]), DirectionArg(args[1])
 	if !dp.IsValid() {
 		return nil, ErrIncorrectDispatcher
 	}
@@ -114,5 +114,5 @@ func HandleCli() (cmd *command, err error) {
 		return nil, ErrIncorrectDirection
 	}
 
-	return &command{dp, dir}, nil
+	return &CommandRequest{dp, dir}, nil
 }

--- a/pkg/hyprwin/hyprwin.go
+++ b/pkg/hyprwin/hyprwin.go
@@ -11,7 +11,11 @@ type manager struct {
 }
 
 func Dispatch(cmd *CommandRequest) (out string, err error) {
-	mgr := manager{cmd, InitIPC()}
+	ipc, err := InitIPC()
+	if err != nil {
+		return "", err
+	}
+	mgr := manager{cmd, ipc}
 
 	win, err := mgr.ipc.ActiveWindow()
 	if err != nil {

--- a/pkg/hyprwin/hyprwin.go
+++ b/pkg/hyprwin/hyprwin.go
@@ -6,12 +6,12 @@ import (
 )
 
 type manager struct {
-	command *command
-	ipc     IPC
+	cmd *CommandRequest
+	ipc IPC
 }
 
-func Dispatch(command *command) (out string, err error) {
-	mgr := manager{command, InitIPC()}
+func Dispatch(cmd *CommandRequest) (out string, err error) {
+	mgr := manager{cmd, InitIPC()}
 
 	win, err := mgr.ipc.ActiveWindow()
 	if err != nil {
@@ -19,10 +19,10 @@ func Dispatch(command *command) (out string, err error) {
 	}
 
 	var resp []byte
-	switch command.dispatcher {
-	case dispatcher("movewindow"):
+	switch cmd.dispatcher {
+	case DispatcherCmd("movewindow"):
 		resp, err = mgr.moveWindow(win)
-	case dispatcher("movefocus"):
+	case DispatcherCmd("movefocus"):
 		resp, err = mgr.moveFocus(win)
 	default:
 		err = errors.New("unknown dispatcher")
@@ -30,10 +30,10 @@ func Dispatch(command *command) (out string, err error) {
 	return string(resp), err
 }
 
-func (m manager) moveWindow(win *winObj) (resp []byte, err error) {
-	dir := m.command.direction.Str()
+func (m manager) moveWindow(win *WinObj) (resp []byte, err error) {
+	dir := m.cmd.direction.Str()
 
-	if m.command.direction.ToMonitor() {
+	if m.cmd.direction.ToMonitor() {
 		return m.ipc.Hyprctl("dispatch moveoutofgroup", "dispatch movewindow "+dir)
 	}
 
@@ -54,8 +54,8 @@ func (m manager) moveWindow(win *winObj) (resp []byte, err error) {
 	return m.ipc.Hyprctl("dispatch movegroupwindow " + dir)
 }
 
-func (m manager) moveFocus(win *winObj) (resp []byte, err error) {
-	dir := m.command.direction.Str()
+func (m manager) moveFocus(win *WinObj) (resp []byte, err error) {
+	dir := m.cmd.direction.Str()
 
 	pos := slices.Index(win.Grouped, win.Address)
 	grpSize := len(win.Grouped)

--- a/pkg/hyprwin/ipc.go
+++ b/pkg/hyprwin/ipc.go
@@ -62,11 +62,11 @@ func InitIPC() (IPC, error) {
 	socketPath := ""
 
 	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
-	tmpDir := filepath.Join(os.TempDir(), "hypr")
+	tmpDir := os.TempDir()
 	dirs := []string{tmpDir, runtimeDir}
 
 	for _, socketHome := range dirs {
-		fpath := filepath.Join(socketHome, sign, ".socket.sock")
+		fpath := filepath.Join(socketHome, "hypr", sign, ".socket.sock")
 		if finfo, err := os.Stat(fpath); err == nil && !finfo.IsDir() {
 			socketPath = fpath
 		}
@@ -77,7 +77,7 @@ func InitIPC() (IPC, error) {
 
 	return &ipc{
 		&net.UnixAddr{
-			Name: "/tmp/hypr/" + sign + "/.socket.sock",
+			Name: socketPath,
 			Net:  "unix",
 		},
 	}, nil

--- a/pkg/hyprwin/ipc.go
+++ b/pkg/hyprwin/ipc.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 )
 
-type winObj struct {
+var BufSize = 8192
+
+type WinObj struct {
 	Grouped        []string `json:"grouped"`
 	Class          string   `json:"class"`
 	Swallowing     string   `json:"swallowing"`
@@ -39,7 +41,7 @@ type wsObj struct {
 
 type IPC interface {
 	Hyprctl(commands ...string) ([]byte, error)
-	ActiveWindow() (*winObj, error)
+	ActiveWindow() (*WinObj, error)
 }
 
 type ipc struct {
@@ -56,17 +58,15 @@ func InitIPC() IPC {
 	}
 }
 
-func (c *ipc) ActiveWindow() (*winObj, error) {
+func (c *ipc) ActiveWindow() (*WinObj, error) {
 	jsonStr, err := c.Hyprctl("activewindow")
 	if err != nil {
 		return nil, err
 	}
-	win := &winObj{}
+	win := &WinObj{}
 	err = json.Unmarshal([]byte(jsonStr), win)
 	return win, err
 }
-
-var BufSize = 8192
 
 // Hyprctl executes commands and returns response. If only one is passed, then sets json flag (-j)
 func (c *ipc) Hyprctl(commands ...string) (resp []byte, err error) {


### PR DESCRIPTION
Makes it possible to work with a socket on a new path in `hyprland-v0.40.0`.
Since this version of **hyprland**, it's **socket is replaced** in `$XDG_RUNTIME_DIR`.

In addition:
- fixes anti-pattern: "returning value of unexported type from an exported function"
- refactores errors handling
- fixes some redundancies